### PR TITLE
Affected by CVE -- product versions handling

### DIFF
--- a/nvdlib/model.py
+++ b/nvdlib/model.py
@@ -115,6 +115,9 @@ class CPE(object):
         self._vulnerable = vulnerable
         self._cpe22Uri = cpe22Uri
         self._cpe23Uri = cpe23Uri
+
+        self._versionExact = cpe.CPE(cpe22Uri).get_version()[0] or None
+
         self._versionStartIncluding = versionStartIncluding
         self._versionStartExcluding = versionStartExcluding
         self._versionEndIncluding = versionEndIncluding
@@ -131,11 +134,11 @@ class CPE(object):
 
     @property
     def vendor(self):
-        return cpe.CPE(self.cpe22Uri).get_vendor()
+        return cpe.CPE(self.cpe22Uri).get_vendor()[0]
 
     @property
     def product(self):
-        return cpe.CPE(self.cpe22Uri).get_product()
+        return cpe.CPE(self.cpe22Uri).get_product()[0]
 
     @property
     def vulnerable(self):
@@ -148,6 +151,10 @@ class CPE(object):
     @property
     def cpe23Uri(self):
         return self._cpe23Uri
+
+    @property
+    def versionExact(self):
+        return self._versionExact
 
     @property
     def versionStartIncluding(self):


### PR DESCRIPTION
- modify vendor and product to return only single value instead of list
as list can be considered unexpacted type

- add versionExact property to CPE which stores a single valued version
instead of version range

--- 

- affects node is now accessible by <cve object>.affects
- additional functionality around affected version:
	- get_affected_vendors
	- get_affected_products
	- get_affected_versions

- introduces AffectsNode and ProductNode classes

Signed-off-by: Marek Cermak <prace.mcermak@gmail.com>

modified:   nvdlib/model.py