### PR TITLE
Remove typing for Python 3.4 compatibility

### DIFF
--- a/nvdlib/model.py
+++ b/nvdlib/model.py
@@ -1,8 +1,6 @@
 import datetime
 import cpe
 
-import typing
-
 from collections import namedtuple
 from enum import Enum
 from itertools import chain
@@ -37,14 +35,14 @@ class CVE(object):
 
         return cpe_list
 
-    def get_affected_vendors(self) -> typing.List[str]:
+    def get_affected_vendors(self) -> list:
         """Get affected vendors.
 
         :returns: List[str], list of affected vendors
         """
         return list(self.affects.keys())
 
-    def get_affected_products(self, vendor: str = None) -> typing.List["ProductNode"]:
+    def get_affected_products(self, vendor: str = None) -> list:
         """Get affected products.
 
         :returns: List[ProductNode], list of affected products
@@ -62,10 +60,10 @@ class CVE(object):
 
         return affected_products
 
-    def get_affected_versions(self, filter_by: typing.Union[tuple, str]) -> typing.List[str]:
+    def get_affected_versions(self, filter_by) -> list:
         """Get affected versions.
 
-        :param filter_by: typing.Union[tuple, str]
+        :param filter_by: Union[tuple, str]
 
             Either tuple of (vendor, product) or cpe string to uniquely identify which
             affected products should be returned.
@@ -82,8 +80,8 @@ class CVE(object):
 
         else:
             raise TypeError(
-                "Argument `by` expected to be {}, got {}".format(
-                    typing.Union[tuple, str], type(filter_by)
+                "Argument `by` expected to be str or tuple, got {}".format(
+                    type(filter_by)
                 ))
 
         affected_versions = list()

--- a/nvdlib/utils.py
+++ b/nvdlib/utils.py
@@ -1,7 +1,6 @@
 """Module containing utilities for nvdlib package."""
 
 import operator
-import typing
 
 from collections import Mapping
 
@@ -50,7 +49,7 @@ class AttrDict(Mapping):
         return getattr(self, key)
 
 
-def get_victims_notation(version_tuple: typing.Sequence):
+def get_victims_notation(version_tuple: list):
     """Maps version range tuple to corresponding victims string notation.
     Assumes arguments ``version_range`` is a tuple or a sequence
     ``(versionExact, versionEndExcluding, versionEndIncluding, versionStartIncluding, versionEndExcluding)``


### PR DESCRIPTION
Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   model.py
modified:   utils.py