### PR TITLE
Use utf-8 encoding when streaming json

### DIFF
--- a/nvdlib/nvd.py
+++ b/nvdlib/nvd.py
@@ -125,7 +125,7 @@ class JsonFeed(object):
 
     def cves(self):
         # TODO: stream the json(?), cache in memory
-        with open(self._data_path, 'r') as f:
+        with open(self._data_path, 'r', encoding='utf-8') as f:
             data = json.load(f).get('CVE_Items', [])
 
         for cve_dict in data:


### PR DESCRIPTION
On some machines, the encoding might default to Latin1 leading to the following issue:

```python
lib/site-packages/nvdlib-0.1-py3.6.egg/nvdlib/nvd.py in cves(self)
    127         # TODO: stream the json(?), cache in memory
    128         with open(self._data_path, 'r') as f:
--> 129             data = json.load(f).get('CVE_Items', [])
    130 
    131         for cve_dict in data:

lib/json/__init__.py in load(fp, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    294 
    295     """
--> 296     return loads(fp.read(),
    297         cls=cls, object_hook=object_hook,
    298         parse_float=parse_float, parse_int=parse_int,

lib/encodings/cp1252.py in decode(self, input, final)
     21 class IncrementalDecoder(codecs.IncrementalDecoder):
     22     def decode(self, input, final=False):
---> 23         return codecs.charmap_decode(input,self.errors,decoding_table)[0]
     24 
     25 class StreamWriter(Codec,codecs.StreamWriter):

UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 5820933: character maps to <undefined>
```

Hence using utf-8 encoding is proposed.